### PR TITLE
HTML Document Loader Refactor 

### DIFF
--- a/notebooks/01-document-loader.ipynb
+++ b/notebooks/01-document-loader.ipynb
@@ -24,7 +24,8 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Parse HTML"
+        "## Parse HTML\n",
+        "Load all of the HTML files into a list of BeautifulSoup objects and create an array of `langchain.docstore.document` objects."
       ]
     },
     {
@@ -33,14 +34,30 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from langchain.document_loaders import BSHTMLLoader\n",
+        "from bs4 import BeautifulSoup\n",
+        "from langchain.docstore.document import Document\n",
+        "from typing import Dict, Union\n",
+        "import unicodedata\n",
+        "\n",
+        "def parse_html(file_path: str) -> Document:\n",
+        "    with open(file_path, \"r\") as file:\n",
+        "        soup = BeautifulSoup(file, \"lxml\")\n",
+        "\n",
+        "    blog_content = soup.find_all(\"div\", class_=\"blog-item-content\")[0].get_text(separator=u' ', strip=True)\n",
+        "    text = unicodedata.normalize(\"NFKC\", blog_content)\n",
+        "    \n",
+        "    metadata: Dict[str, Union[str, None]] = {\n",
+        "        \"source\": file_path,\n",
+        "        \"title\": str(soup.title.string),\n",
+        "    }\n",
+        "\n",
+        "    return Document(page_content=text, metadata=metadata)\n",
         "\n",
         "documents = []\n",
         "\n",
         "for file in os.listdir(\"../html\"):\n",
-        "    loader = BSHTMLLoader(os.path.join(\"../html\", file))\n",
-        "    data = loader.load()\n",
-        "    documents.append(data[0])\n"
+        "    document = parse_html(os.path.join(\"../html\", file))\n",
+        "    documents.append(document)"
       ]
     },
     {
@@ -60,12 +77,11 @@
         "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
         "\n",
         "text_splitter = RecursiveCharacterTextSplitter(\n",
-        "    chunk_size = 450,\n",
-        "    chunk_overlap = 15,\n",
-        "    separators=[\"\\n\\n\", \"\\n\", \" \", \"\"]\n",
+        "    chunk_size = 1500,\n",
+        "    chunk_overlap = 150\n",
         ")\n",
         "\n",
-        "sentences = text_splitter.split_documents(documents)\n"
+        "sentences = text_splitter.split_documents(documents)"
       ]
     },
     {
@@ -127,10 +143,12 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "question = \"Can a baby have water?\"\n",
+        "question = \"Can I give my baby water?\"\n",
+        "#question = \"What is the best yogurt for my baby?\"\n",
+        "#question = \"How do I server a banana?\"\n",
         "response_documents = vectordb.max_marginal_relevance_search(question, k=3)\n",
         "\n",
-        "response_documents[0].page_content[:150]"
+        "response_documents[0].page_content"
       ]
     },
     {
@@ -139,7 +157,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "response_documents[1].page_content[:150]"
+        "response_documents[1].page_content"
       ]
     },
     {
@@ -148,7 +166,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "response_documents[2].page_content[:150]"
+        "response_documents[2].page_content"
       ]
     }
   ],

--- a/poetry.lock
+++ b/poetry.lock
@@ -240,6 +240,19 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "bs4"
+version = "0.0.1"
+description = "Dummy package for Beautiful Soup"
+optional = false
+python-versions = "*"
+files = [
+    {file = "bs4-0.0.1.tar.gz", hash = "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"},
+]
+
+[package.dependencies]
+beautifulsoup4 = "*"
+
+[[package]]
 name = "certifi"
 version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2924,4 +2937,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2d649536297e51d53018cb687a1731fdac09682a4cd96476ae40d85d8eb736b8"
+content-hash = "abd67458b03f6913e3372842df18132ca18f3a4bd9bc043fead32dfb4ddd7807"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ langchain = "^0.0.247"
 lark = "^1.1.7"
 openai = "^0.27.8"
 tiktoken = "^0.4.0"
+bs4 = "^0.0.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR refactors the HTML Document loader as the base `BSHTMLLoader` in `langchain` wasn't flexible enough. Now a `parse_html` method returns a `langchain.docstore.document` containing a SquareSpace blog post. 

A subsequent PR will try to clean up a few more Unicode characters and a content recommendation carousel that shows up on some posts. It includes the same set of keywords in half the documents making the search much less reliable.